### PR TITLE
Create required directories in install.sh

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -2,6 +2,15 @@
 
 set -x
 
+# Setup GemStone directories
+if [ ! -d "/opt/gemstone" ]; then
+	echo "Creating /opt/gemstone to store lock files used by GemStone"
+	sudo mkdir -p /opt/gemstone
+	sudo chmod oug+rwx /opt/gemstone
+	sudo mkdir /opt/gemstone/locks
+	sudo chmod oug+rwx /opt/gemstone/locks
+fi
+
 gsDevKitStones="`dirname $0`/.."
 cd $gsDevKitStones/..
 


### PR DESCRIPTION
It's fair to make the assumption that people using GsDevKit_stones intend to create stones so these directories are required.

GsDevKit_stones users shouldn't have to set these up manually as part of their install.